### PR TITLE
Deconflict env var support from arguments

### DIFF
--- a/py-console/xkdb.py
+++ b/py-console/xkdb.py
@@ -242,8 +242,9 @@ def main():
                         help='optionally specify a backend board to connect to')
     args = parser.parse_args()
 
-    backend_type = args.type
-    if 'CS_CLASS' in os.environ and not args.type:
+    if args.type:
+        backend_type = args.type
+    elif 'CS_CLASS' in os.environ:
         backend_type = os.environ['CS_CLASS']
 
     backend_servers = get_backend_servers(backend_class=backend_type)

--- a/py-console/xkdb.py
+++ b/py-console/xkdb.py
@@ -243,7 +243,7 @@ def main():
     args = parser.parse_args()
 
     backend_type = args.type
-    if 'CS_CLASS' in os.environ:
+    if 'CS_CLASS' in os.environ and not args.type:
         backend_type = os.environ['CS_CLASS']
 
     backend_servers = get_backend_servers(backend_class=backend_type)


### PR DESCRIPTION
Give args.type priority over CS_CLASS environment variable because that's a sneaky thing to break.